### PR TITLE
Update unbound_installer_v1.0beta.sh

### DIFF
--- a/unbound_installer_v1.0beta.sh
+++ b/unbound_installer_v1.0beta.sh
@@ -20,7 +20,7 @@
 ####################################################################################################
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin$PATH
 logger -t "($(basename "$0"))" "$$ Starting Script Execution ($(if [ -n "$1" ]; then echo "$1"; else echo "menu"; fi))"
-VERSION="1.01"
+VERSION="1.02"
 GIT_REPO="unbound-Asuswrt-Merlin"
 GITHUB_DIR="https://raw.githubusercontent.com/rgnldo/$GIT_REPO/master"
 
@@ -64,7 +64,7 @@ welcome_message () {
 		while true; do
 			printf '\n+======================================================================+\n'
 			printf '|  Welcome to the %bunbound-Installer-Asuswrt-Merlin%b installation script |\n' "$COLOR_GREEN" "$COLOR_WHITE"
-			printf '|  Version %s by Martineau                                       |\n' "$VERSION"
+			printf '|  Version %s by Martineau                                           |\n' "$VERSION"
 			printf '|                                                                      |\n'
 			printf '| Requirements: USB drive with Entware installed                       |\n'
 			printf '|                                                                      |\n'
@@ -92,6 +92,8 @@ welcome_message () {
 				if [ "$localmd5" != "$remotemd5" ]; then
 					printf '%b3%b = Update unbound_installer.sh\n' "${COLOR_GREEN}" "${COLOR_WHITE}"
 				fi
+				[ -n "$(pidof unbound)" ] && printf '\n%bs%b = Display unbound statistics\n' "${COLOR_GREEN}" "${COLOR_WHITE}"
+				
 				printf '\n%be%b = Exit Script\n' "${COLOR_GREEN}" "${COLOR_WHITE}"
 				printf '\n%bOption ==>%b ' "${COLOR_GREEN}" "${COLOR_WHITE}"
 				read -r "menu1"
@@ -107,6 +109,10 @@ welcome_message () {
 				;;
 				3)
 					update_installer
+					break
+				;;
+			    s)
+					unbound-control stats_noreset
 					break
 				;;
 				e)
@@ -522,6 +528,7 @@ Customise_config() {
 	 sed -i 's/# do\-udp:.*/do\-udp: yes/' /opt/etc/unbound/unbound.conf
 	 sed -i 's/# do\-tcp:.*/do\-tcp: yes/' /opt/etc/unbound/unbound.conf
 
+	 sed -i 's/#num\-threads:.*/num\-threads: 1/' /opt/etc/unbound/unbound.conf
 	 sed -i 's/msg\-cache\-slabs:.*/msg\-cache\-slabs: 2/' /opt/etc/unbound/unbound.conf
 	 sed -i 's/rrset\-cache\-slabs:.*/rrset\-cache\-slabs: 2/' /opt/etc/unbound/unbound.conf
 	 sed -i 's/infra\-cache\-slabs:.*/infra\-cache\-slabs: 2/' /opt/etc/unbound/unbound.conf


### PR DESCRIPTION
v1.02 Added missing Customise_config() 'num-threads: 1'
Added menu option 's' - Display unbound statistics

+======================================================================+
|  Welcome to the unbound-Installer-Asuswrt-Merlin installation script |
|  Version 1.01 by Martineau                                           |
|                                                                      |
| Requirements: USB drive with Entware installed                       |
|                                                                      |
| The install script will:                                             |
|   1. Install the unbound Entware package                             |
|   2. Override how the firmware manages DNS                           |
|   3. Disable the firmware DNSSEC setting                             |
|                                                                      |
| You can also use this script to uninstall unbound to back out the    |
| changes made during the installation. See the project repository at  |
| https://github.com/rgnldo/Unbound-Asuswrt-Merlin                     |
| for helpful tips.                                                    |
+======================================================================+

1 = Update unbound Configuration
2 = Remove Existing unbound Installation
3 = Update unbound_installer.sh

s = Display unbound statistics

e = Exit Script
